### PR TITLE
Add FreeBSD support; Replace hardcoded redis_sentinel to $module_name…

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,7 +9,7 @@ class redis_sentinel::config {
     group => $redis_sentinel::group,
     mode  => '0440',  
   }
-  
+
   concat::fragment { 'sentinel_header': 
     target  => $redis_sentinel::config_file,
     content => "#This file managed by the redis_sentinel puppet module\ndaemonize yes\nlogfile /var/log/redis/redis-sentinel.log\npidfile /var/run/redis/redis-sentinel.pid",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,7 +10,7 @@ class redis_sentinel::install {
         mode     => '0555',
         owner    => 'root',
         group    => 'root',
-        content => template('redis_sentinel/init.erb'),
+        content => template("${module_name}/init.erb"),
       }
     }
     'Debian': {
@@ -19,7 +19,7 @@ class redis_sentinel::install {
         mode     => '0444',
         owner    => 'root',
         group    => 'root',
-        content => template('redis_sentinel/upstart.erb'),
+        content => template("${module_name}/upstart.erb"),
       }
       file { '/etc/init.d/redis-sentinel':
        ensure => 'link',
@@ -27,6 +27,15 @@ class redis_sentinel::install {
        force  => true,
       }
 
+    }
+    'FreeBSD': {
+      file { '/usr/local/etc/rc.d/redis-sentinel':
+        ensure   => $redis_sentinel::ensure,
+        mode     => '0555',
+        owner    => 'root',
+        group    => 'wheel',
+        content => template("${module_name}/rc.d.erb"),
+      }
     }
     default: { fail('Unknown OS') }
   } 

--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -22,7 +22,7 @@ define redis_sentinel::monitor (
     include redis_sentinel
     concat::fragment { "redis_sentinel_${name}":
       target  => $redis_sentinel::config_file,
-      content => template('redis_sentinel/monitor.erb')
+      content => template("${module_name}/monitor.erb")
     }
   }
 }

--- a/manifests/monitoring.pp
+++ b/manifests/monitoring.pp
@@ -7,20 +7,20 @@ class redis_sentinel::monitoring ($checks_path = "/usr/local/bin") {
     owner  => "root",
     group  => "root",
     mode   => "0755",
-    source => "puppet:///modules/redis_sentinel/check_sentinel"
+    source => "puppet:///modules/${module_name}/check_sentinel"
   }
 
   file { "${checks_path}/check_sentinel_master":
     owner  => "root",
     group  => "root",
     mode   => "0755",
-    source => "puppet:///modules/redis_sentinel/check_sentinel_master"
+    source => "puppet:///modules/${module_name}/check_sentinel_master"
   }
 
   file { "${checks_path}/check_sentinel_master_health":
     owner  => "root",
     group  => "root",
     mode   => "0755",
-    source => "puppet:///modules/redis_sentinel/check_sentinel_master_health"
+    source => "puppet:///modules/${module_name}/check_sentinel_master_health"
   }
 }

--- a/templates/rc.d.erb
+++ b/templates/rc.d.erb
@@ -1,0 +1,30 @@
+#!/bin/sh
+# PROVIDE: redis-sentinel
+# REQUIRE: LOGIN
+# BEFORE:  securelevel
+# KEYWORD: shutdown
+
+# Add the following line to /etc/rc.conf to enable `redis_sentinel':
+#
+#redis_sentinel_enable="YES"
+#
+
+. /etc/rc.subr
+
+name="redis_sentinel"
+rcvar="${name}_enable"
+
+extra_commands="reload"
+
+command="/usr/local/bin/redis-sentinel"
+pidfile="/var/run/redis/redis-sentinel.pid"
+
+# read configuration and set defaults
+load_rc_config "$name"
+: ${redis_sentinel_enable="NO"}
+: ${redis_sentinel_user="root"}
+: ${redis_sentinel_config="<%= scope.lookupvar('redis_sentinel::config_file') -%>"}
+
+command_args="${redis_sentinel_config}"
+required_files="${redis_sentinel_config}"
+run_rc_command "$1"


### PR DESCRIPTION
… in template path

To use with FreeBSD nodes:

```
class { "redis_sentinel": 
                config_file => "/usr/local/etc/redis-sentinel.conf",
}
```

instead of

```
include redis_sentinel
```
